### PR TITLE
Fix syntax error resulting in angular builds failing

### DIFF
--- a/src/styles/astro-ag-theme.css
+++ b/src/styles/astro-ag-theme.css
@@ -4912,7 +4912,7 @@ ag-grid, ag-grid-angular, ag-grid-ng2, ag-grid-polymer, ag-grid-aurelia {
   margin-bottom: 0;
 }
 .ag-theme-astro .ag-dnd-ghost {
-  font-size: var(--font-size-base, 16px)-1;
+  font-size: calc(var(--font-size-base, 16px) - 1px);
   font-weight: 700;
 }
 .ag-theme-astro .ag-side-buttons {


### PR DESCRIPTION
Update line 4915 which throws a build error, SassError: Operators aren't allowed in plain CSS, in an Angular environment.  I believe this fix is what the line was trying to do less explicitly?  Defer to you're call.